### PR TITLE
Split Page object to support multithreading

### DIFF
--- a/src/cherrypy/main.py
+++ b/src/cherrypy/main.py
@@ -37,6 +37,28 @@ class Site:
         self._app_data = AppData(use_azure_blob=self.use_azure_blob, preload=self.preload, external_log_handler=log_handler)
 
 
+
+    @cherrypy.expose
+    def edit(self, **args):
+        req = cherrypy.request
+        args = req.params
+
+        args["root"] = "edit"
+        args["design"] = "dev"
+
+        tc = TimerControl()
+        with tc.new_section("request cherrpy"):
+            ret = self._main("edit", req, tc, args)
+
+        d = tc.dump()
+        logging.debug("TIMERS (%s):\n%s", str(cherrypy.url()), d)
+
+        return ret
+
+
+
+
+
     @cherrypy.expose
     def main(self, **args_p):
         req = cherrypy.request
@@ -44,7 +66,7 @@ class Site:
 
         tc = TimerControl()
         with tc.new_section("request cherrpy"):
-            ret = self._main(req, tc, args)
+            ret = self._main("main", req, tc, args)
 
         d = tc.dump()
         logging.debug("TIMERS (%s):\n%s", str(cherrypy.url()), d)
@@ -52,7 +74,7 @@ class Site:
         return ret
     
 
-    def _main(self, req, tc, args):
+    def _main(self, handle, req, tc, args):
         headers = Headers()
         request = Request(req, RequestType.CHERRY_PY)
 
@@ -66,7 +88,7 @@ class Site:
             except json.JSONDecodeError:
                 pass
 
-        args["root"] = "main"
+        args["root"] = handle
         if "language" not in args.keys():
             args["language"] = "rs"
 

--- a/src/main/__init__.py
+++ b/src/main/__init__.py
@@ -20,6 +20,7 @@ from server.page import Page
 from server.headers import Headers
 from server.request import Request
 from server.timers import TimerControl
+from server.app_data import AppData
 
 #DEBUG
 #from pprint import pprint
@@ -27,7 +28,7 @@ from server.timers import TimerControl
 
 # Cached page object, to speed up load time
 # as advised by: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-PAGE = None
+APP_DATA = None
 
 
 import azure.functions as func
@@ -57,11 +58,12 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
 
 
 def main_work(req: func.HttpRequest, tc: TimerControl) -> func.HttpResponse:
-    global PAGE
-    if PAGE is None:
+    global APP_DATA
+    if APP_DATA is None:
         logging.info("Reloading page (%s, %s)", str(use_azure_blob), str(preload))
-        PAGE = Page(use_azure_blob=use_azure_blob, preload=preload)
+        APP_DATA = AppData(use_azure_blob=use_azure_blob, preload=preload)
 
+    page = Page(APP_DATA)
 
     if False:
         logging.debug("METHOD: " + str(req.method))
@@ -107,7 +109,7 @@ def main_work(req: func.HttpRequest, tc: TimerControl) -> func.HttpResponse:
         args["language"] = "rs"
 
     with tc.new_section("page_main"):
-        page_body = PAGE.main(request, headers, tc, args)
+        page_body = page.main(request, headers, tc, args)
 
     return func.HttpResponse(
         page_body,

--- a/src/server/app_data.py
+++ b/src/server/app_data.py
@@ -1,0 +1,84 @@
+from server.repository import Repository
+import server.storage
+
+import jinja2
+
+import os
+import json
+import logging
+
+
+class AppData:
+
+    # use_azure_blob = True: use blob for question storage rather than the local disk
+    # preload = True: fetch all questions in memory at start time (may be slow for a blob)
+    def __init__(self,
+                 title="tatamata.org",
+                 rel_path=None,
+                 template_path=None,
+                 use_azure_blob=False,
+                 preload=True,
+                 external_log_handler=None):
+
+        #formatter    = logging.Formatter('%(pathname)s:%(funcName)s(%(lineno)d) : %(message)s\n')
+        formatter    = logging.Formatter('%(levelname)s %(filename)s:%(funcName)s(%(lineno)d) : %(message)s\n')
+        rootLogger = logging.getLogger()
+
+        for hdlr in rootLogger.handlers:
+            hdlr.setFormatter(formatter)
+
+        # Any additional handler (e.g. to Azure Log Analytics)
+        if external_log_handler:
+            rootLogger.addHandler(external_log_handler)
+
+        if rel_path:
+            self.rel_path = rel_path
+        else:
+            self.rel_path = os.getenv('SHKOLA_REL_PATH')                    
+
+            if not self.rel_path:
+                self.rel_path = "../.."
+
+        assert self.rel_path
+
+        logging.info("Paths: initial rel_path: {}".format(self.rel_path))
+
+        self.rel_path = os.path.abspath(self.rel_path)
+        logging.info("Paths: rel_path: {}".format(self.rel_path))
+
+        if template_path is None:
+            template_path = os.getenv("SHKOLA_TEMPLATES")
+
+        if template_path is None:
+            template_path = os.path.join(self.rel_path, 'src/templates')
+
+        self.template_path = os.path.abspath(template_path)
+
+        logging.info("Paths: template_path: {}".format(self.template_path))
+        logging.info("Paths: working dir: {}".format(os.getcwd()))
+
+        self.repository = Repository(self.rel_path, use_azure_blob, preload)
+        self.storage = server.storage.get_storage()
+        self.title = title
+        self.load_languages()
+
+        file_loader = jinja2.FileSystemLoader(self.template_path)
+        self.templates = jinja2.Environment(loader=file_loader)
+
+        logging.info("App data loaded")
+
+
+    def load_languages(self):
+        local_path = self.rel_path + "/messages/"
+        self.messages = dict()
+
+        for (dirpath, dirnames, filenames) in os.walk(local_path):
+            for f in filenames:
+                if f[len(f)-5:len(f)] == ".json":
+                    lang = json.load(open(dirpath + f, 'r', encoding='utf-8'))
+                    if lang["key"] in self.messages.keys():
+                        logging.error("Language with key {} defined twice!".format(lang["key"]))
+                    self.messages[lang["key"].lower()] = lang
+
+
+

--- a/src/server/design_default.py
+++ b/src/server/design_default.py
@@ -237,8 +237,7 @@ class Design_default(object):
         menu_id = menu_id + 1
 
         for level in sorted(content.keys()):
-            options = []
-
+            # options = []
             # for theme in sorted(content[level].keys()):
             #     if not theme == "level_short":
             #         options.append({

--- a/src/server/logging_azure.py
+++ b/src/server/logging_azure.py
@@ -1,5 +1,6 @@
 import logging
 import json
+#from pythonjsonlogger import jsonlogger
 import requests
 import datetime
 import hashlib

--- a/src/server/page.py
+++ b/src/server/page.py
@@ -24,18 +24,24 @@ class Page(object):
         'google_site_verification' : GOOGLE_SITE_VERIFICATION
     }
 
-    def __init__(self, app_data):
-        self.app_data = app_data
-        self.page_params = PageParameters()
-        self.userdb = UserDB(self.app_data.storage)
-        self.sessiondb = SessionDB(self.app_data.storage)
 
+    # Explicitly called from edit mode
+    def clear(self):
+        self.page_params = PageParameters()
         self.question = None
         self.lines = []
         self.script_lines = []
-
         self.template_params = self._default_template_params
         self.template_params["title"] = self.app_data.title
+
+
+
+    def __init__(self, app_data):
+        self.app_data = app_data
+        self.clear()
+
+        self.userdb = UserDB(self.app_data.storage)
+        self.sessiondb = SessionDB(self.app_data.storage)
 
         # compatibility
         self.repository = app_data.repository
@@ -134,11 +140,12 @@ class Page(object):
 
 
     def get_default_question(self):
-        return self.app_data.get_all_questions(PageLanguage.toStr(self.page_params.get_param("language")))[0]
+        return self.get_all_questions(PageLanguage.toStr(self.page_params.get_param("language")))[0]
 
 
     def get_default_list(self):
-        return self.app_data.get_all_lists(PageLanguage.toStr(self.page_params.get_param("language")))[0]
+        return self.get_all_lists(PageLanguage.toStr(self.page_params.get_param("language")))[0]
+
 
 
     #################################################

--- a/src/server/page.py
+++ b/src/server/page.py
@@ -1,8 +1,3 @@
-import os
-import os.path
-import json
-import jinja2
-
 from server.types import PageParameters
 from server.types import ResponseOperation
 from server.types import PageOperation
@@ -11,9 +6,7 @@ from server.types import PageDesign
 
 import server.context as context
 
-import server.storage
 import server.helpers as helpers
-from server.repository import Repository
 from server.user_db import UserDB, GOOGLE_CLIENT_ID, GOOGLE_SITE_VERIFICATION
 from server.design import Design
 from server.session import SessionDB
@@ -24,21 +17,6 @@ import logging
 
 
 class Page(object):
-    page_params = None
-
-    question = None
-    storage = None
-    userdb = None
-
-    messages = {}                   # GUI messages in different languages
-
-
-    object_id = 0                   # Unique ID counter for all HTML objects on the page
-    lines = []                      # HTML body lines
-    script_lines = []               # HTML header lines
-    on_loaded_script = ""           # JS code to be run on page load
-    title = ""                      # Web site title in the HTML header
-
 
     _default_template_params = {
         'title' : 'Shkola',
@@ -46,122 +24,28 @@ class Page(object):
         'google_site_verification' : GOOGLE_SITE_VERIFICATION
     }
 
-
-
-    # use_azure_blob = True: use blob for question storage rather than the local disk
-    # preload = True: fetch all questions in memory at start time (may be slow for a blob)
-    def __init__(self, title="tatamata.org", rel_path=None, template_path=None, \
-        use_azure_blob=False, preload=True, external_log_handler=None):
-
-        # Set logging formater
-        # See this for attributes: https://docs.python.org/3/library/logging.html#logrecord-attributes
-        # Note: the usual python way through basicConfig won't work as Azure Functions mess up with it
-        # This is a possible way. See: https://stackoverflow.com/a/57896847
-        # The loop is taken from Logger.callHandlers() implementation
-        # Note: logging.Logger.root should be the root (no parent) but I leave the loop just in case AF change
-        #formatter    = logging.Formatter('%(pathname)s:%(funcName)s(%(lineno)d) : %(message)s\n')
-        formatter    = logging.Formatter('%(levelname)s %(filename)s:%(funcName)s(%(lineno)d) : %(message)s\n')
-        logger = logging.Logger.root
-        while logger:
-            for hdlr in logger.handlers:
-                hdlr.setFormatter(formatter)
-            if not logger.propagate:
-                logger = None    #break out
-            else:
-                logger = logger.parent
-
-
-        # Any additional handler (e.g. to Azure Log Analytics)
-        self.external_log_handler = external_log_handler
-        if external_log_handler:
-            logger = logging.Logger.root
-            logger.addHandler(external_log_handler)
-
-
-        if rel_path:
-            self.rel_path = rel_path
-        else:
-            self.rel_path = os.getenv('SHKOLA_REL_PATH')                    
-
-            if not self.rel_path:
-                self.rel_path = "../.."
-
-        assert self.rel_path
-
-        logging.info("Paths: initial rel_path: {}".format(self.rel_path))
-
-        self.rel_path = os.path.abspath(self.rel_path)
-        logging.info("Paths: rel_path: {}".format(self.rel_path))
-
-        if template_path is None:
-            template_path = os.getenv("SHKOLA_TEMPLATES")
-
-        if template_path is None:
-            template_path = os.path.join(self.rel_path, 'src/templates')
-
-        self.template_path = os.path.abspath(template_path)
-
-        logging.info("Paths: template_path: {}".format(self.template_path))
-        logging.info("Paths: working dir: {}".format(os.getcwd()))
-
+    def __init__(self, app_data):
+        self.app_data = app_data
         self.page_params = PageParameters()
-        self.repository = Repository(self.rel_path, use_azure_blob, preload)
-        self.storage = server.storage.get_storage()
-        self.title = title
-        self.userdb = UserDB(self.storage)
-        self.sessiondb = SessionDB(self.storage)
-        self.load_languages()
+        self.userdb = UserDB(self.app_data.storage)
+        self.sessiondb = SessionDB(self.app_data.storage)
 
-        file_loader = jinja2.FileSystemLoader(self.template_path)
-        self.templates = jinja2.Environment(loader=file_loader)
-        self.template_params = self._default_template_params
-        self.template_params["title"] = self.title
-
-        print("**** Page loaded.\n")
-        self.log_json({"msg":"Page loaded"}, True)
-
-
-    # Send structured log to the log store (if defined)
-    # If not upload_immediately, buffer as required
-    def log_json(self, json_dict, upload_immediately=False):
-        if self.external_log_handler:
-            self.external_log_handler.log_json(json_dict, upload_immediately)
-
-
-    def clear(self):
-        self.page_params = PageParameters()
         self.question = None
         self.lines = []
         self.script_lines = []
-        self.clear_template_params()
 
-
-    def clear_template_params(self):
         self.template_params = self._default_template_params
-        self.template_params["title"] = self.title
+        self.template_params["title"] = self.app_data.title
 
+        # compatibility
+        self.repository = app_data.repository
 
     def add_code(self, init_code = "", iter_code = "", text = ""):
         self.page_params.add_code(init_code, iter_code, text)
-            
 
         
     def add_question(self, question):
         self.question = question
-
-
-
-    def get_all_questions(self, language):
-        l = self.repository.get_all_question_ids("", language)
-        l.sort()
-        return l
-
-    def get_all_lists(self, language=None):
-        l = self.repository.get_all_lists_ids("", language)
-        l.sort()
-        return l
-
-
 
 
     #################################################
@@ -187,7 +71,7 @@ class Page(object):
     #@timer_section("page.render")
     def render(self):
         logging.debug("Render: loading template: '{}'".format(self.template_params["template_name"]))
-        template = self.templates.get_template(self.template_params["template_name"])
+        template = self.app_data.templates.get_template(self.template_params["template_name"])
 
         # Add question as a form parameter
         self.template_params["question"] = ""
@@ -210,54 +94,51 @@ class Page(object):
         # return ret
 
 
-
-
-
-
-
     #################################################
     # Language support
 
-    def load_languages(self):
-        local_path = self.rel_path + "/messages/"
-        self.messages = dict()
+    def get_all_questions(self, language):
+        l = self.app_data.repository.get_all_question_ids("", language)
+        l.sort()
+        return l
 
-        for (dirpath, dirnames, filenames) in os.walk(local_path):
-            for f in filenames:
-                if f[len(f)-5:len(f)] == ".json":
-                    lang = json.load(open(dirpath + f, 'r', encoding='utf-8'))
-                    if lang["key"] in self.messages.keys():
-                        logging.error("Language with key {} defined twice!".format(lang["key"]))
-                    self.messages[lang["key"].lower()] = lang
+
+    def get_all_lists(self, language=None):
+        l = self.app_data.repository.get_all_lists_ids("", language)
+        l.sort()
+        return l
+
 
     def get_language_list(self):
-        return self.messages.keys()
+        return self.app_data.messages.keys()
+
 
     def get_messages(self, language=None):
         if language is None:
             language = PageLanguage.toStr(self.page_params.get_param("language"))
-        if language in self.messages.keys():
-            return self.messages[language]["messages"]
-        return self.messages["rs"]["messages"]
+        if language in self.app_data.messages.keys():
+            return self.app_data.messages[language]["messages"]
+        return self.app_data.messages["rs"]["messages"]
+
 
     def get_language_details(self, language=None):
         if language is None:
             language = PageLanguage.toStr(self.page_params.get_param("language"))
-        if language in self.messages.keys():
-            return self.messages[language]
-        return self.messages["rs"]
+        if language in self.app_data.messages.keys():
+            return self.app_data.messages[language]
+        return self.app_data.messages["rs"]
+
 
     def get_file_url(self, file):
         return "item?url={}".format(file)
 
+
     def get_default_question(self):
-        return self.get_all_questions(PageLanguage.toStr(self.page_params.get_param("language")))[0]
+        return self.app_data.get_all_questions(PageLanguage.toStr(self.page_params.get_param("language")))[0]
+
 
     def get_default_list(self):
-        return self.get_all_lists(PageLanguage.toStr(self.page_params.get_param("language")))[0]
-
-
-
+        return self.app_data.get_all_lists(PageLanguage.toStr(self.page_params.get_param("language")))[0]
 
 
     #################################################
@@ -321,8 +202,6 @@ class Page(object):
         
         
     def main(self, req, headers, timers, args):
-        self.clear()
-
         logging.debug("\n\nMAIN ARGS: {}\n\n".format(args))        
 
         if headers is None or req is None:
@@ -508,10 +387,6 @@ class Page(object):
         return "ABC"
 
 
-
-
-
-
     # args is in format returned by urllib.parse.parse_qs
     def feedback(self, args):
 
@@ -590,9 +465,6 @@ class Page(object):
         return "ABC"
 
 
-
-
-
     def login_google(self):
         id_token = None
         ok = False
@@ -659,8 +531,6 @@ class Page(object):
     #         "?op={}".format(PageOperation.toStr(PageOperation.MENU_YEAR))
 
     #     return url
-
-
 
 
     def login_anon(self) -> str:

--- a/src/server/question.py
+++ b/src/server/question.py
@@ -79,6 +79,7 @@ class Question(object):
         self.lua = LuaRuntime(unpack_returned_tuples=True)
         self.page = page
         self.repository = page.repository
+        self.rel_path = page.app_data.rel_path
 
         # If we have more questions on the same page make sure all use pseudo-random thus unique IDs
         self.q_unique_id = str(int(random.random() * 1000000000))
@@ -122,7 +123,7 @@ class Question(object):
         self.lib = Library(self)
         logging.debug("Rendering question %s, language=%s", 
             self.question_url(), PageLanguage.toStr(self.language))
-        self.questions_root_path = self.page.rel_path + "/" + self.questions_rel_path
+        self.questions_root_path = self.rel_path + "/" + self.questions_rel_path
 
 
     def question_url(self):

--- a/src/server/request.py
+++ b/src/server/request.py
@@ -62,7 +62,7 @@ class Request:
         assert self.method() == 'POST'
 
         if self._rtype == RequestType.CHERRY_PY:
-            return self._request.body_params
+            return self._request.body.params
 
         else:
             if not self._post:

--- a/src/server/test.py
+++ b/src/server/test.py
@@ -49,10 +49,6 @@ class Test(object):
         # Total number of unique questions (including previously asked ones)
         remaining_question = 0
 
-        # At least one eligible question has random values
-        # (i.e. can be asked meaningully several times)
-        randomized_questions = False
-
 
         potential_questions = {
             "all" : [],
@@ -166,7 +162,6 @@ class Test(object):
                 #print("Q: {} ({}) - {} {}".format(next_q["q_id"], add_in_random, diff, remaining_question))
 
                 if add_in_random:
-                    randomized_questions = True
                     potential_questions_w_repeat.append(next_q)
 
         # print("remaining_question={}\npotential_questions={}\npotential_questions_w_repeat={}".format(

--- a/src/server/test.py
+++ b/src/server/test.py
@@ -1,6 +1,5 @@
 import random
 import time
-import json
 
 # from server.question import Question
 from server.types import PageOperation


### PR DESCRIPTION
- Page object is split into AppData and Page. First one is created on startup, second on each request
- I've tested both cherrypy and azure handler, but there still might be some errors because the properties of the page object are changed.
- I didn't test "edit" mode. Edit mode should be merged with the new cherrypy handler (and authentication should be unified).
- I've removed log_json() from the page object. Currently it was only used in one place. I'm not sure I understand the reason for it, shouldn't regular logging methods work ?
- I fixed some pyflakes3 errors. I've left one in test.py because it seems it indicates a presence of a bug (variable is assigned and not used.). @bradunov can you check ?
